### PR TITLE
Inculde license in source tarball

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [metadata]
 description-file = README.md
+licence-file = LICENSE


### PR DESCRIPTION
Currently the `LICENSE` file isn't included in the source tarball on PyPI